### PR TITLE
Fix bug with prices lower than zero

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,16 +5,16 @@ class Product < ApplicationRecord
   has_many :orders, through: :order_items
   has_many :order_items, inverse_of: :product
 
-  def product_price 
-    if (OrderItem.where(product: self).sum(:quantity) > 0) 
-  	 OrderItem.where(product: self).sum(:price) / OrderItem.where(product: self).sum(:quantity) 
-    else 
+  def product_price
+    if total_quantity > 0
+      OrderItem.where(product: self).sum(:price).to_f / total_quantity
+    else
       0
     end
   end
 
   def set_price
-  	@price = self.product_price 
+  	@price = self.product_price
   	update_attribute(:price, @price)
   end
 


### PR DESCRIPTION
Ruby uses integer division by default, so any prices lower than 1.0 were rounded down